### PR TITLE
Fix the full fledge image, which should download the image from network

### DIFF
--- a/lib/landing/timeline/gallery/widgets/timeline_gallery_view_builder.dart
+++ b/lib/landing/timeline/gallery/widgets/timeline_gallery_view_builder.dart
@@ -33,7 +33,7 @@ mixin TimelineGalleryViewBuilder {
 
   PhotoViewGalleryPageOptions _buildImageAsset(GalleryItem item) =>
       PhotoViewGalleryPageOptions(
-        imageProvider: AssetImage(item.imageName),
+        imageProvider: NetworkImage(item.imageName),
         initialScale: PhotoViewComputedScale.contained,
         minScale: PhotoViewComputedScale.contained,
         maxScale: PhotoViewComputedScale.covered * ScaleFactor,


### PR DESCRIPTION
The `ImageProvider` of the `PhotoViewGallery` used to load the image from the asset.
Since the image name now changes to URL, so we need to replace the `ImageProvider` with `NetworkImage`.